### PR TITLE
doc: Fixup README example code, add to doctest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,28 @@ ferray = "0.1"
 use ferray::prelude::*;
 
 // Create arrays
-let a = Array1::<f64>::linspace(0.0, 1.0, 1000)?;
-let b = ferray::ufunc::sin(&a)?;
+let a = ferray::linspace::<f64>(0.0, 1.0, 100, /* include_endpoint= */ true)?;
+let b = ferray::sin(&a)?;
 
 // Linear algebra
-let m = Array2::<f64>::eye(3)?;
+let m = ferray::eye::<f64>(3, 3, /* k (diagonal offset)= */ 0)?;
+#[cfg(feature = "linalg")]
 let det = ferray::linalg::det(&m)?;
 
 // FFT
-let spectrum = ferray::fft::fft(&b, None, None, None)?;
+#[cfg(feature = "fft")]
+let spectrum = ferray::fft::rfft(
+    &b,
+    /* n= */ None,
+    /* axis= */ None,
+    /* norm= */ ferray::fft::FftNorm::Backward,
+)?;
 
 // Statistics
-let mean = ferray::stats::mean(&a, None)?;
-let std = ferray::stats::std(&a, None, None)?;
+let mean = ferray::mean(&a, /* axis= */ None)?;
+let std = ferray::std_(&a, /* axis= */ None, /* ddof= */ 0)?;
+
+Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 ## Performance
@@ -69,7 +78,7 @@ Benchmarked against NumPy 2.3.5 on Linux (Rust 1.85, LTO, target-cpu=native).
 
 For throughput-sensitive workloads, ferray offers `exp_fast()` — an Even/Odd Remez decomposition that is **~30% faster than CORE-MATH** while maintaining ≤1 ULP accuracy (faithfully rounded). It auto-vectorizes for SSE/AVX2/AVX-512/NEON with no lookup tables.
 
-```rust
+```rust ignore
 // Default: correctly rounded (≤0.5 ULP, CORE-MATH)
 let result = ferray::exp(&array)?;
 

--- a/ferray-ufunc/src/fast_exp.rs
+++ b/ferray-ufunc/src/fast_exp.rs
@@ -15,7 +15,11 @@
 /// edge cases: NaN, ±inf, overflow, underflow. Subnormal outputs (x < -708.4)
 /// are flushed to zero.
 #[inline(always)]
-#[allow(clippy::excessive_precision, clippy::approx_constant, clippy::manual_clamp)]
+#[allow(
+    clippy::excessive_precision,
+    clippy::approx_constant,
+    clippy::manual_clamp
+)]
 pub fn exp_fast_f64(x: f64) -> f64 {
     let x_orig = x;
 
@@ -46,8 +50,7 @@ pub fn exp_fast_f64(x: f64) -> f64 {
             + r2 * (4.166666666666667823e-02
                 + r2 * (1.388888888887908173e-03
                     + r2 * (2.480158733642404552e-05
-                        + r2 * (2.755726329888269414e-07
-                            + r2 * 2.091813031817600864e-09)))));
+                        + r2 * (2.755726329888269414e-07 + r2 * 2.091813031817600864e-09)))));
 
     // Odd: sinh(r) via Horner in r² (Remez minimax coefficients)
     let odd = r
@@ -55,8 +58,7 @@ pub fn exp_fast_f64(x: f64) -> f64 {
             + r2 * (1.666666666666667962e-01
                 + r2 * (8.333333333319599412e-03
                     + r2 * (1.984126989005147428e-04
-                        + r2 * (2.755724091443086719e-06
-                            + r2 * 2.511003898736913440e-08)))));
+                        + r2 * (2.755724091443086719e-06 + r2 * 2.511003898736913440e-08)))));
 
     // expm1 reconstruction avoids absorption error from 1 + small
     let expm1 = even + odd;
@@ -139,9 +141,7 @@ mod tests {
     #[test]
     fn accuracy_vs_libm() {
         // Check ≤1 ULP vs libm across a range of values
-        let test_values: Vec<f64> = (-7000..=7097)
-            .map(|i| i as f64 * 0.1)
-            .collect();
+        let test_values: Vec<f64> = (-7000..=7097).map(|i| i as f64 * 0.1).collect();
         for &x in &test_values {
             let fast = exp_fast_f64(x);
             let reference = x.exp();

--- a/ferray-ufunc/src/lib.rs
+++ b/ferray-ufunc/src/lib.rs
@@ -37,7 +37,7 @@ pub use ops::trig::{
 };
 
 // Exponential and logarithmic
-pub use ops::explog::{exp, exp2, exp_fast, expm1, log, log1p, log2, log10, logaddexp, logaddexp2};
+pub use ops::explog::{exp, exp_fast, exp2, expm1, log, log1p, log2, log10, logaddexp, logaddexp2};
 
 // Rounding
 pub use ops::rounding::{around, ceil, fix, floor, rint, round, trunc};

--- a/ferray-ufunc/src/ops/explog.rs
+++ b/ferray-ufunc/src/ops/explog.rs
@@ -9,7 +9,7 @@ use ferray_core::error::FerrayResult;
 use num_traits::Float;
 
 use crate::cr_math::CrMath;
-use crate::helpers::{binary_float_op, unary_float_op, unary_slice_op_f64, unary_slice_op_f32};
+use crate::helpers::{binary_float_op, unary_float_op, unary_slice_op_f32, unary_slice_op_f64};
 
 /// Elementwise exponential (e^x).
 pub fn exp<T, D>(input: &Array<T, D>) -> FerrayResult<Array<T, D>>

--- a/ferray/src/lib.rs
+++ b/ferray/src/lib.rs
@@ -3,6 +3,7 @@
 // This is the top-level crate that users depend on. It re-exports all
 // subcrates into a unified namespace, matching NumPy's `import numpy as np`.
 
+#[doc = include_str!("../../README.md")]
 pub mod config;
 pub mod prelude;
 
@@ -87,7 +88,9 @@ pub use ferray_ufunc::{
 };
 
 // Exponential and logarithmic
-pub use ferray_ufunc::{exp, exp2, exp_fast, expm1, log, log1p, log2, log10, logaddexp, logaddexp2};
+pub use ferray_ufunc::{
+    exp, exp_fast, exp2, expm1, log, log1p, log2, log10, logaddexp, logaddexp2,
+};
 
 // Rounding
 pub use ferray_ufunc::{around, ceil, fix, floor, rint, round, trunc};


### PR DESCRIPTION
Fix problems with initial example code in README.md to make it compile.

Add contents of README.md file to doctests to catch issues in future.

One slight annoyance is that doctests need to demonstrate the return type with `Ok::...`. There does not appear to be a clean way to include this in the README.md file but have it not be visible in the Markdown rendering.

Only the initial example is included as a doctest, second one is ignored.